### PR TITLE
fix(WW-3480): Input Basic - Decimal type should always store a number value

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
         "type": "git",
         "url": "https://github.com/weweb-assets/ww-form-input"
     },
-    "weweb": {
-        "componentPath": "./src/wwElement_InputBasic.vue"
-    },
     "version": "3.3.1",
     "scripts": {
         "build": "weweb build",

--- a/src/composables/useInput.js
+++ b/src/composables/useInput.js
@@ -6,6 +6,9 @@ export function useInput(props, emit) {
     const inputRef = ref(null);
     let debounceTimeout = null;
 
+    // New display value ref to decouple UI from actual value
+    const displayValue = ref('');
+
     const type = computed(() => {
         if (Object.keys(props.wwElementState.props).includes('type')) {
             return props.wwElementState.props.type;
@@ -15,20 +18,52 @@ export function useInput(props, emit) {
 
     function formatValue(value) {
         if (type.value !== 'decimal') return value;
-        if (!value && value !== 0) return '';
-        value = `${value}`.replace(',', '.');
-        const length = value.indexOf('.') !== -1 ? props.content.precision.split('.')[1].length : 0;
-        const newValue = parseFloat(Number(value).toFixed(length).replace(',', '.'));
-        return newValue;
+        if (value === null || value === undefined || value === '') return '';
+
+        // Convert to string and ensure decimal point is '.'
+        const valueStr = `${value}`.replace(',', '.');
+
+        // Determine decimal places from precision setting
+        const precisionStr = props.content.precision;
+        const decimalPlaces = precisionStr.includes('.') ? precisionStr.split('.')[1].length : 0;
+
+        // Format the number with fixed decimal places
+        return Number(valueStr).toFixed(decimalPlaces);
     }
 
-    const defaultValue = computed(() => (props.content.value === undefined ? '' : formatValue(props.content.value)));
+    // Convert string to appropriate type based on input type
+    function parseValue(value) {
+        if (value === '' || value === null || value === undefined) return '';
+
+        if (type.value === 'decimal' || type.value === 'number') {
+            return isNaN(parseFloat(value)) ? value : parseFloat(value);
+        }
+
+        return value;
+    }
+
+    const defaultValue = computed(() => {
+        const rawValue = props.content.value === undefined ? '' : props.content.value;
+        return type.value === 'decimal' || type.value === 'number' ? parseValue(rawValue) : rawValue;
+    });
+
     const { value: variableValue, setValue } = wwLib.wwVariable.useComponentVariable({
         uid: props.uid,
         name: 'value',
-        type: computed(() => (['decimal', 'number'].includes(type.value) ? 'number' : 'string')),
         defaultValue,
     });
+
+    // Initialize display value
+    watch(
+        variableValue,
+        newValue => {
+            // Only update display value if not focused, otherwise it will disrupt typing
+            if (!isReallyFocused.value) {
+                displayValue.value = type.value === 'decimal' ? formatValue(newValue) : String(newValue ?? '');
+            }
+        },
+        { immediate: true }
+    );
 
     /** wwEditor:start */
     watch(defaultValue, () => {
@@ -92,33 +127,55 @@ export function useInput(props, emit) {
     const delay = computed(() => wwLib.wwUtils.getLengthUnit(props.content.debounceDelay)[0]);
 
     function correctDecimalValue(event) {
-        if (type.value === 'decimal') {
-            const newValue = formatValue(variableValue.value);
-            if (newValue === variableValue.value) return;
-            setValue(newValue);
-            emit('trigger-event', { name: 'change', event: { domEvent: event, value: newValue } });
+        if (type.value === 'decimal' && displayValue.value !== '') {
+            const parsedValue = parseValue(displayValue.value);
+            const formattedDisplay = formatValue(parsedValue);
+
+            // Update the display value with proper formatting
+            displayValue.value = formattedDisplay;
+
+            // Always update the actual value to ensure it's in sync with formatted display
+            setValue(parseFloat(formattedDisplay));
+
+            // Only emit the event if the value actually changed
+            if (parsedValue !== variableValue.value) {
+                emit('trigger-event', {
+                    name: 'change',
+                    event: { domEvent: event, value: parsedValue },
+                });
+            }
         }
     }
 
     function handleManualInput(event) {
-        const value = event.target.value;
-        let newValue;
+        const rawValue = event.target.value;
 
-        if (inputType.value === 'number' && (event.data === '.' || event.data === ',') && value === '') {
-            return;
-        } else if (inputType.value === 'number' && (value === 0 || (value && value.length))) {
+        // Update display value as user types
+        displayValue.value = rawValue;
+
+        // For decimal/number, only parse when sending events
+        let parsedValue;
+
+        if (inputType.value === 'number' && (rawValue === 0 || (rawValue && rawValue.length))) {
             try {
-                newValue = parseFloat(value);
+                parsedValue = parseFloat(rawValue);
+                if (isNaN(parsedValue)) {
+                    parsedValue = rawValue;
+                }
             } catch (error) {
-                newValue = value;
+                parsedValue = rawValue;
             }
         } else {
-            newValue = value;
+            parsedValue = rawValue;
         }
 
-        if (newValue === props.value) return;
-        setValue(newValue);
+        // Avoid updating if the value hasn't changed
+        if (parsedValue === variableValue.value) return;
 
+        // Update the actual value
+        setValue(parsedValue);
+
+        // Trigger events
         if (props.content.debounce) {
             isDebouncing.value = true;
             if (debounceTimeout) {
@@ -127,14 +184,14 @@ export function useInput(props, emit) {
             debounceTimeout = setTimeout(() => {
                 emit('trigger-event', {
                     name: 'change',
-                    event: { domEvent: event, value: newValue },
+                    event: { domEvent: event, value: parsedValue },
                 });
-                emit('element-event', { type: 'change', value: { domEvent: event, value: newValue } });
+                emit('element-event', { type: 'change', value: { domEvent: event, value: parsedValue } });
                 isDebouncing.value = false;
             }, delay.value);
         } else {
-            emit('trigger-event', { name: 'change', event: { domEvent: event, value: newValue } });
-            emit('element-event', { type: 'change', value: { domEvent: event, value: newValue } });
+            emit('trigger-event', { name: 'change', event: { domEvent: event, value: parsedValue } });
+            emit('element-event', { type: 'change', value: { domEvent: event, value: parsedValue } });
         }
     }
 
@@ -202,8 +259,10 @@ export function useInput(props, emit) {
         () => props.content.precision,
         (newValue, oldValue) => {
             if (newValue === oldValue) return;
-            const value = formatValue(variableValue.value);
-            setValue(value);
+            // Only format if not currently focused
+            if (!isReallyFocused.value && variableValue.value !== '') {
+                displayValue.value = formatValue(variableValue.value);
+            }
         }
     );
     /* wwEditor:end */
@@ -211,6 +270,7 @@ export function useInput(props, emit) {
     return {
         inputRef,
         variableValue,
+        displayValue,
         isReallyFocused,
         isDebouncing,
         type,

--- a/src/wwElement.vue
+++ b/src/wwElement.vue
@@ -18,7 +18,7 @@
         :class="{ editing: isEditing }"
         @input="handleManualInput"
         @focus="isReallyFocused = true"
-        @blur="isReallyFocused = false"
+        @blur="onBlur"
         @keyup.enter="onEnter"
     />
 </template>
@@ -40,7 +40,6 @@ export default {
         /* wwEditor:end */
         uid: { type: String, required: true },
         wwElementState: { type: Object, required: true },
-        useForm: { type: Boolean, default: true }, // TODO => Prevent specific component from using form
     },
     emits: [
         'element-event',
@@ -65,6 +64,7 @@ export default {
         const {
             inputRef,
             variableValue,
+            displayValue,
             isReallyFocused,
             isDebouncing,
             type,
@@ -98,7 +98,7 @@ export default {
         const inputBindings = computed(() => ({
             ...props.wwElementState.props.attributes,
             key: 'ww-input-basic-' + step.value,
-            value: variableValue.value,
+            value: displayValue.value,
             type: inputType.value,
             name: props.wwElementState.name,
             readonly: isReadonly.value || isEditing.value,
@@ -113,7 +113,7 @@ export default {
 
         const textareaBindings = computed(() => ({
             ...props.wwElementState.props.attributes,
-            value: variableValue.value,
+            value: displayValue.value,
             type: props.content.type,
             name: props.wwElementState.name,
             readonly: isReadonly.value || isEditing.value,


### PR DESCRIPTION
This refactor the component a little bit : now we separate the display value for the input from the internal component value.
This is useful for decimal inputs where we want to format the input value in a certain way (type string), but we want to keep the component variable value of type number.